### PR TITLE
fix: the resource "scopes" did'nt match the resource "applicationscopes" defined in oam-dev/sepc and oam-dev/oam-go-sdk

### DIFF
--- a/charts/admission/templates/admission.yaml
+++ b/charts/admission/templates/admission.yaml
@@ -64,7 +64,7 @@ webhooks:
       - apiGroups:   ["core.oam.dev"]
         apiVersions: ["v1alpha1"]
         operations:  ["CREATE", "UPDATE"]
-        resources:   ["scopes"]
+        resources:   ["applicationscopes"]
         scope:       "Namespaced"
     clientConfig:
       service:

--- a/common/common.go
+++ b/common/common.go
@@ -16,7 +16,7 @@ const (
 	// ComponentCRD is the resources of the Component
 	ComponentCRD = "componentschematics"
 	// ScopeCRD is the resources of the Scope
-	ScopeCRD = "scopes"
+	ScopeCRD = "applicationscopes"
 	// TraitCRD is the resources of the Trait
 	TraitCRD = "traits"
 )


### PR DESCRIPTION
```shell script
$ kubectl -n oam-system logs admission-55c988b8c8-smsc5 -f
I0315 07:31:40.404743       1 main.go:103] server starting, listening on 
E0315 07:31:40.427674       1 reflector.go:125] github.com/oam-dev/admission-controller/pkg/client/informers/externalversions/factory.go:115: Failed to list *v1alpha1.Scope: the server could not find the requested resource (get scopes.core.oam.dev)
E0315 07:31:41.434013       1 reflector.go:125] github.com/oam-dev/admission-controller/pkg/client/informers/externalversions/factory.go:115: Failed to list *v1alpha1.Scope: the server could not find the requested resource (get scopes.core.oam.dev)
E0315 07:31:42.437372       1 reflector.go:125] github.com/oam-dev/admission-controller/pkg/client/informers/externalversions/factory.go:115: Failed to list *v1alpha1.Scope: the server could not find the requested resource (get scopes.core.oam.dev)
E0315 07:31:43.440797       1 reflector.go:125] github.com/oam-dev/admission-controller/pkg/client/informers/externalversions/factory.go:115: Failed to list *v1alpha1.Scope: the server could not find the requested resource (get scopes.core.oam.dev)
...
```